### PR TITLE
Fix neverland-ansi_bg spelling error

### DIFF
--- a/colors/neverland-ansi_bg.vim
+++ b/colors/neverland-ansi_bg.vim
@@ -22,7 +22,7 @@ let g:colors_name="neverland-ansi_bg"
 
 if &t_Co > 255
    hi Normal          ctermfg=225 ctermbg=000 cterm=none
-   set backround=dark
+   set background=dark
 
    hi Boolean         ctermfg=135 ctermbg=000 cterm=bold
    hi Character       ctermfg=143 ctermbg=000 cterm=none


### PR DESCRIPTION
You had 'backround' and I believe you intended to use "background". 

Also - neverland-ansi_bg doesn't work in Gvim and changes to a light background. I don't quite know why.
