### PR TITLE
gVim colour definition updates + some cleanup

### DIFF
--- a/colors/neverland-darker.vim
+++ b/colors/neverland-darker.vim
@@ -153,10 +153,10 @@ if &t_Co > 255
    hi Operator        ctermfg=148
 
    " complete menu
-   hi Pmenu           ctermfg=137 ctermbg=000 cterm=none
+   hi Pmenu           ctermfg=137 ctermbg=16  cterm=none
    hi PmenuSel        ctermfg=196 ctermbg=235 cterm=bold
-   hi PmenuSbar       ctermfg=000 ctermbg=233 cterm=none
-   hi PmenuThumb      ctermfg=137 ctermbg=000 cterm=none
+   hi PmenuSbar       ctermfg=16  ctermbg=233 cterm=none
+   hi PmenuThumb      ctermfg=137 ctermbg=16  cterm=none
 
    hi PreCondit       ctermfg=118               cterm=bold
    hi PreProc         ctermfg=218

--- a/colors/neverland.vim
+++ b/colors/neverland.vim
@@ -162,10 +162,10 @@ if &t_Co > 255
    hi Operator        ctermfg=148
 
    " complete menu
-   hi Pmenu           ctermfg=137 ctermbg=000 cterm=none
+   hi Pmenu           ctermfg=137 ctermbg=16  cterm=none
    hi PmenuSel        ctermfg=196 ctermbg=235 cterm=bold
-   hi PmenuSbar       ctermfg=000 ctermbg=233 cterm=none
-   hi PmenuThumb      ctermfg=137 ctermbg=000 cterm=none
+   hi PmenuSbar       ctermfg=16  ctermbg=233 cterm=none
+   hi PmenuThumb      ctermfg=137 ctermbg=16  cterm=none
 
    hi PreCondit       ctermfg=118               cterm=bold
    hi PreProc         ctermfg=218

--- a/colors/neverland2-darker.vim
+++ b/colors/neverland2-darker.vim
@@ -157,10 +157,10 @@ if &t_Co > 255
    hi Operator        ctermfg=46
 
    " complete menu
-   hi Pmenu           ctermfg=137 ctermbg=000 cterm=none
+   hi Pmenu           ctermfg=137 ctermbg=16  cterm=none
    hi PmenuSel        ctermfg=196 ctermbg=235 cterm=bold
-   hi PmenuSbar       ctermfg=000 ctermbg=233 cterm=none
-   hi PmenuThumb      ctermfg=137 ctermbg=000 cterm=none
+   hi PmenuSbar       ctermfg=16  ctermbg=233 cterm=none
+   hi PmenuThumb      ctermfg=137 ctermbg=16  cterm=none
 
    hi PreCondit       ctermfg=118               cterm=bold
    hi PreProc         ctermfg=218

--- a/colors/neverland2.vim
+++ b/colors/neverland2.vim
@@ -154,10 +154,10 @@ if &t_Co > 255
    hi Operator        ctermfg=46
 
    " complete menu
-   hi Pmenu           ctermfg=137 ctermbg=000 cterm=none
+   hi Pmenu           ctermfg=137 ctermbg=16  cterm=none
    hi PmenuSel        ctermfg=196 ctermbg=235 cterm=bold
-   hi PmenuSbar       ctermfg=000 ctermbg=233 cterm=none
-   hi PmenuThumb      ctermfg=137 ctermbg=000 cterm=none
+   hi PmenuSbar       ctermfg=16  ctermbg=233 cterm=none
+   hi PmenuThumb      ctermfg=137 ctermbg=16  cterm=none
 
    hi PreCondit       ctermfg=118               cterm=bold
    hi PreProc         ctermfg=218


### PR DESCRIPTION
I've updated the gVim colours for all the colourschemes to match those of the most up to date CLI counter-parts.

I also changed some cterm definitions (for the completion menu) from '000' to '16'. I noticed the colour of both those values is the same (black), so I just changed it to be more consistent.
